### PR TITLE
Limit freeboard and compute uncertainty estimates

### DIFF
--- a/awi_als_toolbox/_grid.py
+++ b/awi_als_toolbox/_grid.py
@@ -910,7 +910,7 @@ class ALSMergedGrid(object):
         # Check which variables to grid
         self.coord_names = ['lat', 'lon', 'xc', 'yc', 'time', 'time_bnds']
         self.cfg = cfg
-        print(self.cfg.offset_correction['correcting_fields'])
+        #print(self.cfg.offset_correction['correcting_fields'])
         try:
             self.grid_variable_names = [i for i in self.cfg.variable_attributes.keys() if i not in self.coord_names and not i.endswith('_offset_cor_uncertainty')]
             self.correcting_fields = self.cfg.offset_correction['correcting_fields']
@@ -1129,9 +1129,9 @@ class ALSMergedGrid(object):
             except ImportError:
                 logger.error("Install packages floenavi and icedrift for ice drift corrected lat/lon values")
         
-        data_vars["lon"] = xr.Variable(grid_dims, self.lons.astype(np.float32),
+        data_vars["lon"] = xr.Variable(grid_dims, self.lons.astype(np.float64),
                                        attrs=self.cfg.get_var_attrs("lon"))
-        data_vars["lat"] = xr.Variable(coord_dims, self.lats.astype(np.float32),
+        data_vars["lat"] = xr.Variable(coord_dims, self.lats.astype(np.float64),
                                        attrs=self.cfg.get_var_attrs("lat"))
 
         # Collect all coords
@@ -1638,6 +1638,12 @@ def extract_low_reflectance_regions(grid, thres=3,filt_size=5,chunk_size=0.5,min
     emean = uniform_filter(eref,size=background_scale)/uniform_filter(mask_eref.astype('float'),size=background_scale)
     emean[~mask_eref] = np.nan
     ebckg_reg = emean[mask] - eref_reg
+    
+    # Mask leads, i.e. e<emean
+    mask_leads = grid.nc['elevation'].data[mask]<emean[mask]
+    t_reg = t_reg[mask_leads]
+    eref_reg = eref_reg[mask_leads]
+    ebckg_reg = ebckg_reg[mask_leads]
 
     # Initialze data arrays for clusters
     t = []

--- a/awi_als_toolbox/export.py
+++ b/awi_als_toolbox/export.py
@@ -99,9 +99,9 @@ class AlsDEMNetCDF(object):
         # Add additional variables
         data_vars["n_points"] = xr.Variable(grid_dims, self.dem.n_shots.astype(np.int16),
                                             attrs=self.cfg.get_var_attrs("n_points"))
-        data_vars["lon"] = xr.Variable(coord_dims, self.dem.lon.astype(np.float32),
+        data_vars["lon"] = xr.Variable(coord_dims, self.dem.lon.astype(np.float64),
                                        attrs=self.cfg.get_var_attrs("lon"))
-        data_vars["lat"] = xr.Variable(coord_dims, self.dem.lat.astype(np.float32),
+        data_vars["lat"] = xr.Variable(coord_dims, self.dem.lat.astype(np.float64),
                                        attrs=self.cfg.get_var_attrs("lat"))
 
         # Add grid mapping

--- a/awi_als_toolbox/filter.py
+++ b/awi_als_toolbox/filter.py
@@ -232,6 +232,9 @@ class OffsetCorrectionFilter(ALSPointCloudFilter):
         # Check for correction files stored
         self.corr_files = [ifile for ifile in os.listdir('./') if ifile.endswith(self.cfg['export_file'])]
         
+        if len(self.corr_files)==0:
+            logger.info('ELEVCOR: Warning - OffsetCorrectionFilter called without providing correction files')
+        
         # Apply correction to als object
         for icor in self.corr_files:
             fpath = Path(icor).absolute()

--- a/awi_als_toolbox/freeboard.py
+++ b/awi_als_toolbox/freeboard.py
@@ -210,7 +210,7 @@ class DetectOpenWater(ALSPointCloudFilter):
         # -----> Error in atmospheric backscatter
         
 
-        logger.info("OpenWaterDetection is applied")
+        logger.info("OWDETC: OpenWaterDetection is applied")
         
         # 1. Find NADIR pixels in data
         
@@ -308,7 +308,7 @@ class DetectOpenWater(ALSPointCloudFilter):
             rflc_thres = self.cfg["rflc_thres"]
             rflc_owp = rflc_nadir[owp]
             if self.cfg["rflc_minmax"]:
-                logger.info(" - using also maxima of reflectance for open water detection")
+                logger.info("OWDETC:  - using also maxima of reflectance for open water detection")
                 mask = np.abs(rflc_owp - np.nanmean(rflc_nadir_m))> rflc_thres
             else:
                 mask = np.nanmean(rflc_nadir_m) - rflc_owp > rflc_thres
@@ -351,7 +351,7 @@ class DetectOpenWater(ALSPointCloudFilter):
 
                 ind_start = i + 1
 
-            logger.info('Number of open water points: %i and clusters: %i' %(owp.size,len(cluster_info)))
+            logger.info('OWDETC: Number of open water points: %i and clusters: %i' %(owp.size,len(cluster_info)))
 
             # 6. (optional) plot results of open water detection
             if do_plot:
@@ -366,7 +366,7 @@ class DetectOpenWater(ALSPointCloudFilter):
                 if savefig:
                     fig.savefig(Path(self.cfg["export_file"]).absolute().parent.joinpath(als.tcs_segment_datetime.strftime('Open_water_detection_%Y%m%dT%H%M%S.jpg')), 
                                 dpi=300)
-                    logger.info('Stored open water detection image to %s' %Path(self.cfg["export_file"]).absolute().parent.joinpath('Open_water_detection_%s.jpg' %als.tcs_segment_datetime))
+                    logger.info('OWDETC: Stored open water detection image to %s' %Path(self.cfg["export_file"]).absolute().parent.joinpath('Open_water_detection_%s.jpg' %als.tcs_segment_datetime))
 
 
             # 7. Export open water points
@@ -374,7 +374,7 @@ class DetectOpenWater(ALSPointCloudFilter):
             self._export_open_water_clusters(cluster_info,als)
             
         else:
-            logger.info('Warning: all nadir elevations in this segment are NaN')
+            logger.info('OWDETC: Warning: all nadir elevations in this segment are NaN')
 
     
     def _export_open_water_points(self, inds_peak, als):
@@ -450,13 +450,20 @@ class AlsFreeboardConversion(object):
             self.export_file = Path(self.cfg['OpenWaterDetection']['export_file']).absolute()
         else:
             self.export_file = Path('open_water_points.csv').absolute()
-        logger.info('Open water points are exported to: %s' %str(self.export_file))
+        logger.info('FBCONV: Open water points are exported to: %s' %str(self.export_file))
         
         if 'floe_grid' not in self.cfg['OpenWaterDetection'].keys():
             self.cfg['OpenWaterDetection']['floe_grid'] = False
             
         # Store modifications in dem_cfg
         cfg = self.cfg
+        
+        # Output config file
+        for ikey in cfg:
+            logger.info('FBCONV CFG: %s' %ikey)
+            for ikeys in cfg[ikey]:
+                logger.info('FBCONV CFG:  - %s : %s' %(ikeys,cfg[ikey][ikeys]))
+                
         
         # Initialise interpolation function
         self.func = None
@@ -546,7 +553,7 @@ class AlsFreeboardConversion(object):
                                          s=0.03,ext='const')
             
         except AttributeError:
-            logger.error('export_file is not specified')
+            logger.error('FBCONV: export_file is not specified')
     
     
     @property        
@@ -561,7 +568,7 @@ class AlsFreeboardConversion(object):
         #    logger.info('Warning: value of config interp2d in the sea surface interpolation is overwritten by input to: %i' %interp2d)
         #    self.cfg['SeaSurfaceInterpolation']['interp2d'] = interp2d
         if self.cfg['SeaSurfaceInterpolation']['interp2d']: # Use 2d interpolation of open water points
-            logger.info('Freeboard conversion: 2d interpolation of freeboard is activated')
+            logger.info('FBCONV: Freeboard conversion: 2d interpolation of freeboard is activated')
             try:
                 # 0. Read csv
                 self.read_csv()
@@ -569,7 +576,7 @@ class AlsFreeboardConversion(object):
                     # 1. Get projection to use to interpolate
                     self.p = pyproj.Proj(dem_cfg.projection)
                     self.xow, self.yow = self.p(self.lonow,self.latow)
-                    logger.info('WARNING: config projection is used to compute freeboard positions, which potentially interferes with Ice Drift Correction')
+                    logger.info('FBCONV: WARNING: config projection is used to compute freeboard positions, which potentially interferes with Ice Drift Correction')
 
                 # 2. Define 2d interpolation function
                 #self.func = SmoothBivariateSpline(self.xow,self.yow,self.eow)
@@ -598,7 +605,7 @@ class AlsFreeboardConversion(object):
                 als._shot_vars['freeboard'] = freeboard
                     
             except AttributeError:
-                logger.error('No cfg-file is provided to take projection from')
+                logger.error('FBCONV: No cfg-file is provided to take projection from')
                 
             
         else: # use timestamp for interpolation


### PR DESCRIPTION
This pull request includes the following new features mainly focussing on the freeboard conversion:

- The interpolated sea surface height is limited with the lower envelope of the elevation surface (minimum elevation in the surrounding, 250m) and a maximum freeboard of the lower envelope of 4m.
- freeboard uncertainty based on the estimated raw uncertainty of the elevation data, the elevation correction applied at each point in comparison to the nearest neighbouring open water point, and the correction from limiting the interpolated sea surface height.
- filename of floe grids are in same format as 30s-segments, solves #25
- correct lat/lon positions in double precision, solves #26  