### PR TITLE
Timing ice drift correction

### DIFF
--- a/awi_als_toolbox/_bindata.py
+++ b/awi_als_toolbox/_bindata.py
@@ -834,7 +834,8 @@ class ALSMetadata(object):
                  "geospatial_lat_units", "geospatial_lat_resolution", "geospatial_lon_units",
                  "geospatial_lon_resolution", "geospatial_vertical_units", "geospatial_vertical_resolution",
                  "date_issued", "date_metadata_modified", "product_version", "platform", "platform_vocabulary",
-                 "instrument", "instrument_vocabulary", "cdm_data_type", "metadata_link", "references"]
+                 "instrument", "instrument_vocabulary", "cdm_data_type", "metadata_link", "references",
+                 "reference_time_drift_correction"]
 
     def __init__(self):
         """ Product Metadata following Attribute Convention for Data Discovery 1.3 """

--- a/awi_als_toolbox/_grid.py
+++ b/awi_als_toolbox/_grid.py
@@ -227,8 +227,11 @@ class AlsDEM(object):
         # IDC TODO reverse the IceDriftCorrection is needed here!
         # IDC else:
         if self.IceDriftCorrection:
-            reftime = self.als.tcs_segment_datetime + 0.5*(self.als.tce_segment_datetime-self.als.tcs_segment_datetime) 
-            icepos = self.als.IceCoordinateSystem.get_latlon_coordinates(self.dem_x, self.dem_y, reftime)
+            #reftime = self.als.tcs_segment_datetime + 0.5*(self.als.tce_segment_datetime-self.als.tcs_segment_datetime)
+            idc_cfg = self.cfg.input_filter[np.where([ifilt['pyclass']=='IceDriftCorrection' for ifilt in self.cfg.input_filter])[0][0]]
+            self.gridreftime = idc_cfg['keyw']['reftime']
+            self.metadata.set_attribute("reference_time_drift_correction", self.gridreftime)
+            icepos = self.als.IceCoordinateSystem.get_latlon_coordinates(self.dem_x, self.dem_y, self.gridreftime)
             self.lon ,self.lat = icepos.longitude, icepos.latitude
         else:
             self.lon, self.lat = self.p(self.dem_x, self.dem_y, inverse=True)
@@ -1112,7 +1115,8 @@ class ALSMergedGrid(object):
             data_vars[grid_variable_name] = xr.Variable(grid_dims,self.grid[grid_variable_name].astype(np.float32),
                                             attrs=self.cfg.get_var_attrs(grid_variable_name))
             
-        self.reftime = datetime(1970,1,1,0,0,0) + timedelta(0,np.mean(self.reftimes))
+        #self.reftime = datetime(1970,1,1,0,0,0) + timedelta(0,np.mean(self.reftimes))
+        self.reftime = self.cfg.ice_drift_correction['keyw']['reftime']
         if recompute_latlon == True:
             try:
                 from floenavi.polarstern import PolarsternAWIDashboardPos

--- a/awi_als_toolbox/filter.py
+++ b/awi_als_toolbox/filter.py
@@ -155,6 +155,13 @@ class IceDriftCorrection(ALSPointCloudFilter):
         # 6. Store projected coordinates
         als.x[nonan] = icepos.xc
         als.y[nonan] = icepos.yc
+        
+        # 6. a) Replace lat lon with dirft corrected lat lons
+        icepos = self.IceCoordinateSystem.get_latlon_coordinates(als.x[nonan], als.y[nonan], self.cfg["reftime"])
+        lon,lat = als.get('longitude'), als.get('latitude')
+        lon[nonan],lat[nonan] = icepos.longitude, icepos.latitude
+        als.set('longitude',lon)
+        als.set('latitude',lat)
 
         # 7. Set IceDriftCorrected
         als.IceDriftCorrected = True

--- a/awi_als_toolbox/filter.py
+++ b/awi_als_toolbox/filter.py
@@ -120,12 +120,12 @@ class IceDriftCorrection(ALSPointCloudFilter):
     Corrects for ice drift during data aquisition, using floenavi or Polarstern position
     """
 
-    def __init__(self,use_polarstern=False,reftimes=None):
+    def __init__(self,use_polarstern=False,reftimes=None,reftime=None):
         """
         Initialize the filter.
         :param filter_threshold_m:
         """
-        super(IceDriftCorrection, self).__init__(use_polarstern=use_polarstern,reftimes=reftimes)
+        super(IceDriftCorrection, self).__init__(use_polarstern=use_polarstern,reftimes=reftimes,reftime=reftime)
 
     def apply(self, als):
         """

--- a/awi_als_toolbox/filter.py
+++ b/awi_als_toolbox/filter.py
@@ -53,11 +53,15 @@ class AtmosphericBackscatterFilter(ALSPointCloudFilter):
         # first mode of elevations
         elevations = als.get('elevation')
         # Determine elevation of first mode
-        hist,bins = np.histogram(elevations[np.isfinite(elevations)],bins=100)
+        #hist,bins = np.histogram(elevations[np.isfinite(elevations)],bins=100)
+        hist,bins = np.histogram(elevations[np.isfinite(elevations)],
+                                 bins=np.arange(np.nanmin(elevations),
+                                                np.nanmax(elevations),0.5))
         diff = np.diff(np.append(np.zeros((1,)),hist))
         if np.any(np.all([diff[1:]<0,diff[:-1]>0],axis=0)):
-            ind_peak = np.where(np.all([diff[1:]<0,diff[:-1]>0],axis=0))[0][0]
-            min_mode_elev = np.mean(bins[ind_peak:ind_peak+2])
+            ind_peaks = np.where(np.all([diff[1:]<0,diff[:-1]>0],axis=0))#[0][0]
+            ice_mode = ind_peaks[0][np.argmax(hist[ind_peaks])]
+            min_mode_elev = np.mean(bins[ice_mode:ice_mode+2])#ind_peak:ind_peak+2])
         else:
             min_mode_elev = np.nanmean(elevations)
         threshold = 20


### PR DESCRIPTION
This pull request includes fixes to use the same reference time for computing lat/lon positions with the ice drift correction for both 30s segments and floe gird. The reference time is now also included as an attribute in the 30s segment netcdf files and the lat/lon positions of open water points are drift corrected as well.

In addition the atmospheric backscatter filter has been modified to identify sea ice elevations as the strongest mode of elevations within a 30s segment. 